### PR TITLE
Add docker agent exposure rules and reduce false positives

### DIFF
--- a/pkg/analysis/context/analyzer.go
+++ b/pkg/analysis/context/analyzer.go
@@ -218,6 +218,12 @@ func (ca *ContextAnalyzer) ShouldSuppress(ruleID string, ctx *WorkflowContext) b
 		// Suppress for read-only workflows with no permission needs
 		return ctx.Intent.IsReadOnly() && ctx.PermissionNeeds.IsEmpty()
 
+	case "ARTIPACKED_VULNERABILITY":
+		// Suppress for trusted workflows that don't handle untrusted input.
+		// The token exposure via persist-credentials is only exploitable if an
+		// attacker can read .git/config from an uploaded artifact or step output.
+		return ctx.IsTrusted && !ctx.HasUntrustedInput
+
 	default:
 		return false
 	}

--- a/pkg/concurrent/concurrent.go
+++ b/pkg/concurrent/concurrent.go
@@ -372,7 +372,7 @@ func (cp *ConcurrentProcessor) analyzeWorkflowConcurrently(ctx context.Context, 
 
 		var standardFindings []rules.Finding
 		// Use the RuleEngine for context-aware analysis (severity adjustment, suppression)
-		engine := rules.NewRuleEngine(nil)
+		engine := rules.NewRuleEngine(job.Config)
 		standardFindings = engine.ExecuteRules(job.Workflow, job.StandardRules)
 
 		mu.Lock()

--- a/pkg/concurrent/concurrent.go
+++ b/pkg/concurrent/concurrent.go
@@ -364,17 +364,9 @@ func (cp *ConcurrentProcessor) analyzeWorkflowConcurrently(ctx context.Context, 
 		defer wg.Done()
 
 		var standardFindings []rules.Finding
-		for _, rule := range job.StandardRules {
-			select {
-			case <-ctx.Done():
-				errChan <- ctx.Err()
-				return
-			default:
-			}
-
-			findings := rule.Check(job.Workflow)
-			standardFindings = append(standardFindings, findings...)
-		}
+		// Use the RuleEngine for context-aware analysis (severity adjustment, suppression)
+		engine := rules.NewRuleEngine(nil)
+		standardFindings = engine.ExecuteRules(job.Workflow, job.StandardRules)
 
 		mu.Lock()
 		allFindings = append(allFindings, standardFindings...)

--- a/pkg/concurrent/concurrent.go
+++ b/pkg/concurrent/concurrent.go
@@ -363,6 +363,13 @@ func (cp *ConcurrentProcessor) analyzeWorkflowConcurrently(ctx context.Context, 
 	go func() {
 		defer wg.Done()
 
+		select {
+		case <-ctx.Done():
+			errChan <- ctx.Err()
+			return
+		default:
+		}
+
 		var standardFindings []rules.Finding
 		// Use the RuleEngine for context-aware analysis (severity adjustment, suppression)
 		engine := rules.NewRuleEngine(nil)

--- a/pkg/engine/hybrid.go
+++ b/pkg/engine/hybrid.go
@@ -389,13 +389,13 @@ func DefaultConfig() Config {
 }
 
 // detectRepositoryOwner attempts to determine the repository owner from
-// the git remote URL. Falls back to the parent directory name if parsing fails.
+// the git remote URL. Falls back to the repository directory name if parsing fails.
 func detectRepositoryOwner(repoPath string) string {
 	// Try reading .git/config for remote origin URL
 	gitConfigPath := filepath.Join(repoPath, ".git", "config")
 	data, err := os.ReadFile(gitConfigPath)
 	if err != nil {
-		return filepath.Base(filepath.Dir(repoPath))
+		return filepath.Base(repoPath)
 	}
 
 	content := string(data)

--- a/pkg/engine/hybrid.go
+++ b/pkg/engine/hybrid.go
@@ -389,13 +389,13 @@ func DefaultConfig() Config {
 }
 
 // detectRepositoryOwner attempts to determine the repository owner from
-// the git remote URL or falls back to the directory name.
+// the git remote URL. Falls back to the parent directory name if parsing fails.
 func detectRepositoryOwner(repoPath string) string {
 	// Try reading .git/config for remote origin URL
 	gitConfigPath := filepath.Join(repoPath, ".git", "config")
 	data, err := os.ReadFile(gitConfigPath)
 	if err != nil {
-		return ""
+		return filepath.Base(filepath.Dir(repoPath))
 	}
 
 	content := string(data)
@@ -419,18 +419,23 @@ func detectRepositoryOwner(repoPath string) string {
 				continue
 			}
 			url := strings.TrimSpace(parts[1])
-			return ownerFromRemoteURL(url)
+			owner := ownerFromRemoteURL(url)
+			if owner != "" {
+				return owner
+			}
 		}
 	}
 
-	return ""
+	// Fallback: use parent directory name as a best-effort owner guess
+	return filepath.Base(filepath.Dir(repoPath))
 }
 
 // ownerFromRemoteURL extracts the owner/org from a git remote URL.
-// Supports: https://github.com/owner/repo.git, git@github.com:owner/repo.git
+// Supports: https://github.com/owner/repo.git, git@github.com:owner/repo.git,
+// ssh://git@github.com/owner/repo.git
 func ownerFromRemoteURL(url string) string {
-	// SSH format: git@github.com:owner/repo.git
-	if strings.Contains(url, ":") && strings.Contains(url, "@") {
+	// SSH scp-style format: git@github.com:owner/repo.git
+	if strings.Contains(url, ":") && strings.Contains(url, "@") && !strings.HasPrefix(url, "ssh://") {
 		colonIdx := strings.LastIndex(url, ":")
 		path := url[colonIdx+1:]
 		path = strings.TrimSuffix(path, ".git")
@@ -440,10 +445,11 @@ func ownerFromRemoteURL(url string) string {
 		}
 	}
 
+	// SSH URL format: ssh://git@github.com/owner/repo.git
 	// HTTPS format: https://github.com/owner/repo.git
 	url = strings.TrimSuffix(url, ".git")
 	parts := strings.Split(url, "/")
-	// URL like https://github.com/owner/repo → parts[3] is owner
+	// URL like https://github.com/owner/repo → parts[len-2] is owner
 	if len(parts) >= 4 {
 		return parts[len(parts)-2]
 	}

--- a/pkg/engine/hybrid.go
+++ b/pkg/engine/hybrid.go
@@ -18,6 +18,7 @@ package engine
 
 import (
 	"fmt"
+	"os"
 	"path/filepath"
 	"strings"
 
@@ -27,6 +28,7 @@ import (
 	"github.com/harekrishnarai/flowlyt/pkg/platform/github"
 	"github.com/harekrishnarai/flowlyt/pkg/platform/gitlab"
 	"github.com/harekrishnarai/flowlyt/pkg/rules"
+	"gopkg.in/yaml.v3"
 )
 
 // HybridEngine combines Go-native rules with OPA policies
@@ -147,6 +149,9 @@ func (he *HybridEngine) AnalyzeRepository(repoPath string) (*AnalysisResult, err
 		Performance: PerformanceMetrics{},
 	}
 
+	// Detect repository owner from git remote or path
+	repoOwner := detectRepositoryOwner(repoPath)
+
 	// Try each platform to find workflows
 	var allWorkflows []*platform.Workflow
 
@@ -167,6 +172,7 @@ func (he *HybridEngine) AnalyzeRepository(repoPath string) (*AnalysisResult, err
 			if err != nil {
 				continue // Skip invalid workflows
 			}
+			workflow.RepositoryOwner = repoOwner
 			allWorkflows = append(allWorkflows, workflow)
 			result.Statistics.PlatformBreakdown[workflow.Platform]++
 		}
@@ -282,13 +288,22 @@ func (he *HybridEngine) analyzeWithGoRules(workflow *platform.Workflow) []rules.
 
 // convertToLegacyWorkflow converts new platform.Workflow to legacy parser.WorkflowFile
 func (he *HybridEngine) convertToLegacyWorkflow(workflow *platform.Workflow) parser.WorkflowFile {
-	// This is a temporary bridge - we'll eventually migrate all rules to use platform.Workflow
-	return parser.WorkflowFile{
-		Path:    workflow.FilePath,
-		Name:    workflow.Name,
-		Content: workflow.Content,
-		// For now, we'll need to implement conversion logic based on platform
+	wf := parser.WorkflowFile{
+		Path:            workflow.FilePath,
+		Name:            workflow.Name,
+		Content:         workflow.Content,
+		RepositoryOwner: workflow.RepositoryOwner,
 	}
+
+	// Parse the YAML content into the Workflow struct for rule analysis
+	if len(workflow.Content) > 0 {
+		var parsed parser.Workflow
+		if err := yaml.Unmarshal(workflow.Content, &parsed); err == nil {
+			wf.Workflow = parsed
+		}
+	}
+
+	return wf
 }
 
 // detectPlatformFromPath detects platform based on workflow file path
@@ -371,4 +386,67 @@ func DefaultConfig() Config {
 			Verbose:         false,
 		},
 	}
+}
+
+// detectRepositoryOwner attempts to determine the repository owner from
+// the git remote URL or falls back to the directory name.
+func detectRepositoryOwner(repoPath string) string {
+	// Try reading .git/config for remote origin URL
+	gitConfigPath := filepath.Join(repoPath, ".git", "config")
+	data, err := os.ReadFile(gitConfigPath)
+	if err != nil {
+		return ""
+	}
+
+	content := string(data)
+	// Look for url = patterns in [remote "origin"] section
+	lines := strings.Split(content, "\n")
+	inOrigin := false
+	for _, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if trimmed == `[remote "origin"]` {
+			inOrigin = true
+			continue
+		}
+		if strings.HasPrefix(trimmed, "[") {
+			inOrigin = false
+			continue
+		}
+		if inOrigin && strings.HasPrefix(trimmed, "url") {
+			// Extract URL
+			parts := strings.SplitN(trimmed, "=", 2)
+			if len(parts) != 2 {
+				continue
+			}
+			url := strings.TrimSpace(parts[1])
+			return ownerFromRemoteURL(url)
+		}
+	}
+
+	return ""
+}
+
+// ownerFromRemoteURL extracts the owner/org from a git remote URL.
+// Supports: https://github.com/owner/repo.git, git@github.com:owner/repo.git
+func ownerFromRemoteURL(url string) string {
+	// SSH format: git@github.com:owner/repo.git
+	if strings.Contains(url, ":") && strings.Contains(url, "@") {
+		colonIdx := strings.LastIndex(url, ":")
+		path := url[colonIdx+1:]
+		path = strings.TrimSuffix(path, ".git")
+		parts := strings.Split(path, "/")
+		if len(parts) >= 1 {
+			return parts[0]
+		}
+	}
+
+	// HTTPS format: https://github.com/owner/repo.git
+	url = strings.TrimSuffix(url, ".git")
+	parts := strings.Split(url, "/")
+	// URL like https://github.com/owner/repo → parts[3] is owner
+	if len(parts) >= 4 {
+		return parts[len(parts)-2]
+	}
+
+	return ""
 }

--- a/pkg/engine/hybrid.go
+++ b/pkg/engine/hybrid.go
@@ -426,8 +426,8 @@ func detectRepositoryOwner(repoPath string) string {
 		}
 	}
 
-	// Fallback: use parent directory name as a best-effort owner guess
-	return filepath.Base(filepath.Dir(repoPath))
+	// Fallback: use repository directory name as a best-effort owner guess
+	return filepath.Base(repoPath)
 }
 
 // ownerFromRemoteURL extracts the owner/org from a git remote URL.

--- a/pkg/engine/hybrid.go
+++ b/pkg/engine/hybrid.go
@@ -408,7 +408,7 @@ func detectRepositoryOwner(repoPath string) string {
 	gitConfigPath := filepath.Join(repoPath, ".git", "config")
 	data, err := os.ReadFile(gitConfigPath)
 	if err != nil {
-		return filepath.Base(repoPath)
+		return ""
 	}
 
 	content := string(data)
@@ -439,8 +439,9 @@ func detectRepositoryOwner(repoPath string) string {
 		}
 	}
 
-	// Fallback: use repository directory name as a best-effort owner guess
-	return filepath.Base(repoPath)
+	// Fallback: cannot determine owner without git remote — return empty
+	// so same-org checks are skipped rather than making wrong assumptions
+	return ""
 }
 
 // ownerFromRemoteURL extracts the owner/org from a git remote URL.

--- a/pkg/engine/hybrid.go
+++ b/pkg/engine/hybrid.go
@@ -232,6 +232,19 @@ func (he *HybridEngine) AnalyzeWorkflow(workflowPath string) (*AnalysisResult, e
 		return nil, fmt.Errorf("failed to parse workflow: %w", err)
 	}
 
+	// Attempt to set RepositoryOwner by walking up to find the repo root
+	if workflow.RepositoryOwner == "" {
+		absPath, _ := filepath.Abs(workflowPath)
+		dir := filepath.Dir(absPath)
+		for dir != "/" && dir != "." {
+			if _, err := os.Stat(filepath.Join(dir, ".git")); err == nil {
+				workflow.RepositoryOwner = detectRepositoryOwner(dir)
+				break
+			}
+			dir = filepath.Dir(dir)
+		}
+	}
+
 	result.Workflows = []*platform.Workflow{workflow}
 	result.Statistics.TotalWorkflows = 1
 	result.Statistics.PlatformBreakdown[workflow.Platform] = 1

--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -51,6 +51,9 @@ type Job struct {
 	Permissions     interface{}            `yaml:"permissions,omitempty"`
 	Needs           interface{}            `yaml:"needs,omitempty"`
 	If              string                 `yaml:"if,omitempty"`
+	Uses            string                 `yaml:"uses,omitempty"`
+	With            map[string]interface{} `yaml:"with,omitempty"`
+	Secrets         interface{}            `yaml:"secrets,omitempty"`
 	Steps           []Step                 `yaml:"steps"`
 	Env             map[string]string      `yaml:"env,omitempty"`
 	Defaults        map[string]interface{} `yaml:"defaults,omitempty"`

--- a/pkg/platform/platform.go
+++ b/pkg/platform/platform.go
@@ -32,16 +32,17 @@ type Platform interface {
 
 // Workflow represents a generic CI/CD workflow structure
 type Workflow struct {
-	Platform    string                 `json:"platform"`
-	Name        string                 `json:"name"`
-	FilePath    string                 `json:"file_path"`
-	Content     []byte                 `json:"content,omitempty"`
-	Triggers    []Trigger              `json:"triggers"`
-	Jobs        []Job                  `json:"jobs"`
-	Environment map[string]string      `json:"environment,omitempty"`
-	Permissions interface{}            `json:"permissions,omitempty"`
-	Variables   map[string]interface{} `json:"variables,omitempty"`
-	Metadata    map[string]interface{} `json:"metadata,omitempty"`
+	Platform        string                 `json:"platform"`
+	Name            string                 `json:"name"`
+	FilePath        string                 `json:"file_path"`
+	Content         []byte                 `json:"content,omitempty"`
+	Triggers        []Trigger              `json:"triggers"`
+	Jobs            []Job                  `json:"jobs"`
+	Environment     map[string]string      `json:"environment,omitempty"`
+	Permissions     interface{}            `json:"permissions,omitempty"`
+	Variables       map[string]interface{} `json:"variables,omitempty"`
+	Metadata        map[string]interface{} `json:"metadata,omitempty"`
+	RepositoryOwner string                 `json:"repository_owner,omitempty"`
 }
 
 // Job represents a job in a CI/CD workflow

--- a/pkg/rules/docker_agent_exposure.go
+++ b/pkg/rules/docker_agent_exposure.go
@@ -1,0 +1,454 @@
+/*
+Copyright 2025 Hare Krishna Rai
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package rules
+
+import (
+	"regexp"
+	"strings"
+
+	"github.com/harekrishnarai/flowlyt/pkg/linenum"
+	"github.com/harekrishnarai/flowlyt/pkg/parser"
+)
+
+// CheckDockerAgentExposure detects pull_request_target workflows that run
+// Docker containers or reusable agent workflows with secrets on fork code.
+func CheckDockerAgentExposure(workflow parser.WorkflowFile) []Finding {
+	var findings []Finding
+
+	if !hasPullRequestTargetTrigger(workflow) {
+		return findings
+	}
+
+	findings = append(findings, checkDockerExecWithSecrets(workflow)...)
+	findings = append(findings, checkReusableWorkflowAgentExposure(workflow)...)
+
+	return findings
+}
+
+// checkReusableWorkflowAgentExposure detects job-level reusable workflow calls
+// that pass secrets to agent/review/bot workflows under pull_request_target.
+func checkReusableWorkflowAgentExposure(workflow parser.WorkflowFile) []Finding {
+	var findings []Finding
+
+	agentWorkflowPatterns := []*regexp.Regexp{
+		regexp.MustCompile(`(?i)review.*pull.*request`),
+		regexp.MustCompile(`(?i)review-pr`),
+		regexp.MustCompile(`(?i)agent`),
+		regexp.MustCompile(`(?i)bot.*respond`),
+		regexp.MustCompile(`(?i)ai.*review`),
+		regexp.MustCompile(`(?i)code.*review`),
+		regexp.MustCompile(`(?i)auto.*review`),
+		regexp.MustCompile(`(?i)respond.*comment`),
+		regexp.MustCompile(`(?i)triage.*issue`),
+	}
+
+	for jobName, job := range workflow.Workflow.Jobs {
+		if job.Uses == "" {
+			continue
+		}
+
+		if !strings.Contains(job.Uses, ".github/workflows/") {
+			continue
+		}
+
+		isAgentWorkflow := false
+		for _, pattern := range agentWorkflowPatterns {
+			if pattern.MatchString(job.Uses) {
+				isAgentWorkflow = true
+				break
+			}
+		}
+		if !isAgentWorkflow {
+			continue
+		}
+
+		hasSecrets := false
+		if job.Secrets != nil {
+			switch s := job.Secrets.(type) {
+			case string:
+				if s == "inherit" {
+					hasSecrets = true
+				}
+			case map[string]interface{}:
+				if len(s) > 0 {
+					hasSecrets = true
+				}
+			case map[interface{}]interface{}:
+				if len(s) > 0 {
+					hasSecrets = true
+				}
+			}
+		}
+
+		if !hasSecrets {
+			contentStr := string(workflow.Content)
+			if strings.Contains(contentStr, "secrets:") {
+				hasSecrets = true
+			}
+		}
+
+		if !hasSecrets {
+			continue
+		}
+
+		severity := High
+		contentStr := string(workflow.Content)
+		if strings.Contains(contentStr, "PRIVATE_KEY") ||
+			strings.Contains(contentStr, "API_KEY") ||
+			strings.Contains(contentStr, "inherit") {
+			severity = Critical
+		}
+
+		finding := Finding{
+			RuleID:      "DOCKER_EXEC_WITH_SECRETS_ON_FORK_CODE",
+			RuleName:    "Reusable Agent Workflow Called With Secrets on pull_request_target",
+			Description: "A pull_request_target workflow calls a reusable workflow that runs an AI agent or automated review, passing secrets including API keys or private keys. The downstream workflow checks out fork code and processes it in a container with these secrets available, enabling secret exfiltration by external attackers.",
+			Severity:    severity,
+			Category:    SecretExposure,
+			FilePath:    workflow.Path,
+			JobName:     jobName,
+			StepName:    "",
+			Evidence:    "uses: " + job.Uses,
+			Remediation: "Ensure downstream Docker containers use --network=none. Do not forward secrets into containers processing fork code. Require a maintainer label before running agents on fork PRs.",
+			LineNumber:  1,
+		}
+		findings = append(findings, finding)
+	}
+
+	return findings
+}
+
+// checkDockerExecWithSecrets detects direct docker run commands that forward
+// secrets via -e/--env while operating on fork code without network isolation.
+func checkDockerExecWithSecrets(workflow parser.WorkflowFile) []Finding {
+	var findings []Finding
+	lineMapper := linenum.NewLineMapper(workflow.Content)
+
+	dockerRunWithEnv := []*regexp.Regexp{
+		regexp.MustCompile(`docker\s+run\b[^;|&]*\s-e\s`),
+		regexp.MustCompile(`docker\s+run\b[^;|&]*\s--env\s`),
+		regexp.MustCompile(`docker\s+run\b[^;|&]*\s--env-file\s`),
+	}
+
+	secretEnvPatterns := []*regexp.Regexp{
+		regexp.MustCompile(`-e\s+\w*(KEY|TOKEN|SECRET|PASSWORD|CREDENTIAL)\w*`),
+		regexp.MustCompile(`--env\s+\w*(KEY|TOKEN|SECRET|PASSWORD|CREDENTIAL)\w*`),
+		regexp.MustCompile(`-e\s+\$\{\{\s*secrets\.\w+\s*\}\}`),
+		regexp.MustCompile(`--env\s+\w+=\$\{\{\s*secrets\.\w+\s*\}\}`),
+	}
+
+	networkNone := regexp.MustCompile(`--network[=\s]+none`)
+
+	for jobName, job := range workflow.Workflow.Jobs {
+		for stepIdx, step := range job.Steps {
+			if step.Run == "" {
+				continue
+			}
+
+			hasDockerEnv := false
+			for _, pattern := range dockerRunWithEnv {
+				if pattern.MatchString(step.Run) {
+					hasDockerEnv = true
+					break
+				}
+			}
+			if !hasDockerEnv {
+				continue
+			}
+
+			if networkNone.MatchString(step.Run) {
+				continue
+			}
+
+			hasSecretForward := false
+			for _, pattern := range secretEnvPatterns {
+				if pattern.MatchString(step.Run) {
+					hasSecretForward = true
+					break
+				}
+			}
+
+			if !hasSecretForward && job.Env != nil {
+				for key, value := range job.Env {
+					if strings.Contains(value, "secrets.") {
+						keyUpper := strings.ToUpper(key)
+						if strings.Contains(keyUpper, "KEY") || strings.Contains(keyUpper, "TOKEN") ||
+							strings.Contains(keyUpper, "SECRET") || strings.Contains(keyUpper, "PASSWORD") {
+							hasSecretForward = true
+							break
+						}
+					}
+				}
+			}
+
+			if !hasSecretForward {
+				continue
+			}
+
+			stepName := step.Name
+			if stepName == "" {
+				stepName = "Step " + string(rune('1'+stepIdx))
+			}
+
+			linePattern := linenum.FindPattern{
+				Key:   "run",
+				Value: step.Run,
+			}
+			lineResult := lineMapper.FindLineNumber(linePattern)
+			lineNumber := 1
+			if lineResult != nil {
+				lineNumber = lineResult.LineNumber
+			}
+
+			finding := Finding{
+				RuleID:      "DOCKER_EXEC_WITH_SECRETS_ON_FORK_CODE",
+				RuleName:    "Docker Container Runs Fork Code With Secrets",
+				Description: "A pull_request_target workflow runs a Docker container with secrets forwarded via -e/--env while operating on fork code without --network=none isolation. An external attacker can exfiltrate secrets by opening a PR with malicious files.",
+				Severity:    Critical,
+				Category:    SecretExposure,
+				FilePath:    workflow.Path,
+				JobName:     jobName,
+				StepName:    stepName,
+				Evidence:    step.Run,
+				Remediation: "Add --network=none to docker run to prevent network exfiltration. Remove unnecessary secrets from the container environment.",
+				LineNumber:  lineNumber,
+			}
+			findings = append(findings, finding)
+		}
+	}
+
+	findings = append(findings, checkIndirectDockerWithSecrets(workflow, lineMapper)...)
+
+	return findings
+}
+
+// checkIndirectDockerWithSecrets detects step-level reusable workflow/action
+// calls that pass secrets to agent/review workflows under pull_request_target.
+func checkIndirectDockerWithSecrets(workflow parser.WorkflowFile, lineMapper *linenum.LineMapper) []Finding {
+	var findings []Finding
+
+	agentWorkflowPatterns := []*regexp.Regexp{
+		regexp.MustCompile(`(?i)review.*pull.*request`),
+		regexp.MustCompile(`(?i)agent`),
+		regexp.MustCompile(`(?i)bot.*respond`),
+		regexp.MustCompile(`(?i)ai.*review`),
+		regexp.MustCompile(`(?i)code.*review`),
+		regexp.MustCompile(`(?i)auto.*review`),
+	}
+
+	for jobName, job := range workflow.Workflow.Jobs {
+		for stepIdx, step := range job.Steps {
+			if step.Uses == "" {
+				continue
+			}
+
+			if !strings.Contains(step.Uses, ".github/workflows/") &&
+				!strings.Contains(step.Uses, ".github/actions/") {
+				continue
+			}
+
+			isAgentWorkflow := false
+			for _, pattern := range agentWorkflowPatterns {
+				if pattern.MatchString(step.Uses) {
+					isAgentWorkflow = true
+					break
+				}
+			}
+			if !isAgentWorkflow {
+				continue
+			}
+
+			hasSecrets := false
+			if step.With != nil {
+				for key, value := range step.With {
+					if valueStr, ok := value.(string); ok {
+						if strings.Contains(valueStr, "secrets.") ||
+							strings.Contains(strings.ToLower(key), "token") ||
+							strings.Contains(strings.ToLower(key), "key") {
+							hasSecrets = true
+							break
+						}
+					}
+				}
+			}
+
+			if !hasSecrets {
+				contentStr := string(workflow.Content)
+				if strings.Contains(contentStr, "secrets: inherit") {
+					hasSecrets = true
+				}
+			}
+
+			if !hasSecrets {
+				continue
+			}
+
+			stepName := step.Name
+			if stepName == "" {
+				stepName = "Step " + string(rune('1'+stepIdx))
+			}
+
+			finding := Finding{
+				RuleID:      "DOCKER_EXEC_WITH_SECRETS_ON_FORK_CODE",
+				RuleName:    "Reusable Workflow Runs Agent on Fork Code With Secrets",
+				Description: "A pull_request_target workflow passes secrets to a reusable workflow that runs an AI agent or automated review on fork code. If the downstream container lacks network isolation, an external attacker can exfiltrate secrets via malicious PR files.",
+				Severity:    High,
+				Category:    SecretExposure,
+				FilePath:    workflow.Path,
+				JobName:     jobName,
+				StepName:    stepName,
+				Evidence:    "uses: " + step.Uses,
+				Remediation: "Audit the reusable workflow to ensure Docker containers use --network=none and secrets are not forwarded into containers processing fork code.",
+				LineNumber:  1,
+			}
+			findings = append(findings, finding)
+		}
+	}
+
+	return findings
+}
+
+// checkAIAgentOnUntrustedCode detects AI agent invocations that process
+// untrusted fork code with secrets available, enabling indirect prompt injection.
+func checkAIAgentOnUntrustedCode(workflow parser.WorkflowFile) []Finding {
+	var findings []Finding
+
+	if !hasPullRequestTargetTrigger(workflow) {
+		return findings
+	}
+
+	lineMapper := linenum.NewLineMapper(workflow.Content)
+
+	aiAgentPatterns := []*regexp.Regexp{
+		regexp.MustCompile(`(?i)\b(oz|claude|copilot|gpt|openai|anthropic)\s+(agent|run|review)`),
+		regexp.MustCompile(`(?i)\bagent\s+run\b`),
+		regexp.MustCompile(`(?i)\bclaude\s+(-p|--prompt|code)\b`),
+		regexp.MustCompile(`(?i)docker\s+run\b[^;|&]*(agent|review|bot|ai)[^;|&]*`),
+		regexp.MustCompile(`(?i)\b(aider|cursor|continue|cody|devin|sweep)\b.*\b(run|start|review)\b`),
+	}
+
+	aiStepNamePatterns := []*regexp.Regexp{
+		regexp.MustCompile(`(?i)(ai|agent|bot|llm|gpt|claude|copilot).*(review|analyze|respond|triage)`),
+		regexp.MustCompile(`(?i)(review|analyze|respond|triage).*(ai|agent|bot|llm|gpt|claude|copilot)`),
+		regexp.MustCompile(`(?i)auto.*review`),
+		regexp.MustCompile(`(?i)code.*review.*bot`),
+	}
+
+	aiActionPatterns := []*regexp.Regexp{
+		regexp.MustCompile(`(?i)(oz-agent|ai-review|code-review-bot|pr-review|auto-review)`),
+		regexp.MustCompile(`(?i)(anthropic|openai|claude|copilot).*action`),
+	}
+
+	for jobName, job := range workflow.Workflow.Jobs {
+		for stepIdx, step := range job.Steps {
+			isAIStep := false
+			evidence := ""
+
+			if step.Run != "" {
+				for _, pattern := range aiAgentPatterns {
+					if pattern.MatchString(step.Run) {
+						isAIStep = true
+						evidence = step.Run
+						break
+					}
+				}
+			}
+
+			if !isAIStep && step.Name != "" {
+				for _, pattern := range aiStepNamePatterns {
+					if pattern.MatchString(step.Name) {
+						isAIStep = true
+						evidence = "step name: " + step.Name
+						break
+					}
+				}
+			}
+
+			if !isAIStep && step.Uses != "" {
+				for _, pattern := range aiActionPatterns {
+					if pattern.MatchString(step.Uses) {
+						isAIStep = true
+						evidence = "uses: " + step.Uses
+						break
+					}
+				}
+			}
+
+			if !isAIStep {
+				continue
+			}
+
+			hasSecrets := hasSecretsAccess(step)
+			if !hasSecrets && job.Env != nil {
+				for _, value := range job.Env {
+					if strings.Contains(value, "secrets.") {
+						hasSecrets = true
+						break
+					}
+				}
+			}
+			if !hasSecrets && step.Env != nil {
+				for _, value := range step.Env {
+					if strings.Contains(strings.ToUpper(value), "KEY") ||
+						strings.Contains(strings.ToUpper(value), "TOKEN") {
+						hasSecrets = true
+						break
+					}
+				}
+			}
+
+			severity := High
+			if !hasSecrets {
+				severity = Medium
+			}
+
+			stepName := step.Name
+			if stepName == "" {
+				stepName = "Step " + string(rune('1'+stepIdx))
+			}
+
+			lineNumber := 1
+			if step.Run != "" {
+				linePattern := linenum.FindPattern{
+					Key:   "run",
+					Value: step.Run,
+				}
+				lineResult := lineMapper.FindLineNumber(linePattern)
+				if lineResult != nil {
+					lineNumber = lineResult.LineNumber
+				}
+			}
+
+			finding := Finding{
+				RuleID:      "AI_AGENT_ON_UNTRUSTED_CODE",
+				RuleName:    "AI Agent Processes Untrusted Fork Code With Secrets",
+				Description: "A pull_request_target workflow runs an AI agent that processes fork-controlled code with secrets in its environment and network access. Attacker-controlled files can contain indirect prompt injection payloads that trick the agent into exfiltrating secrets.",
+				Severity:    severity,
+				Category:    SecretExposure,
+				FilePath:    workflow.Path,
+				JobName:     jobName,
+				StepName:    stepName,
+				Evidence:    evidence,
+				Remediation: "Add --network=none to agent containers. Treat all file contents as untrusted in agent prompts. Remove secrets from the agent environment if not needed. Require a maintainer label before running agents on fork PRs.",
+				LineNumber:  lineNumber,
+			}
+			findings = append(findings, finding)
+		}
+	}
+
+	return findings
+}

--- a/pkg/rules/docker_agent_exposure.go
+++ b/pkg/rules/docker_agent_exposure.go
@@ -43,6 +43,7 @@ func CheckDockerAgentExposure(workflow parser.WorkflowFile) []Finding {
 // that pass secrets to agent/review/bot workflows under pull_request_target.
 func checkReusableWorkflowAgentExposure(workflow parser.WorkflowFile) []Finding {
 	var findings []Finding
+	lineMapper := linenum.NewLineMapper(workflow.Content)
 
 	agentWorkflowPatterns := []*regexp.Regexp{
 		regexp.MustCompile(`(?i)review.*pull.*request`),
@@ -108,6 +109,16 @@ func checkReusableWorkflowAgentExposure(workflow parser.WorkflowFile) []Finding 
 			}
 		}
 
+		lineNumber := 1
+		linePattern := linenum.FindPattern{
+			Key:   "uses",
+			Value: job.Uses,
+		}
+		lineResult := lineMapper.FindLineNumber(linePattern)
+		if lineResult != nil {
+			lineNumber = lineResult.LineNumber
+		}
+
 		finding := Finding{
 			RuleID:      "DOCKER_EXEC_WITH_SECRETS_ON_FORK_CODE",
 			RuleName:    "Reusable Agent Workflow Called With Secrets on pull_request_target",
@@ -119,7 +130,7 @@ func checkReusableWorkflowAgentExposure(workflow parser.WorkflowFile) []Finding 
 			StepName:    "",
 			Evidence:    "uses: " + job.Uses,
 			Remediation: "Ensure downstream Docker containers use --network=none. Do not forward secrets into containers processing fork code. Require a maintainer label before running agents on fork PRs.",
-			LineNumber:  1,
+			LineNumber:  lineNumber,
 		}
 		findings = append(findings, finding)
 	}
@@ -144,6 +155,7 @@ func checkDockerExecWithSecrets(workflow parser.WorkflowFile) []Finding {
 		regexp.MustCompile(`-e\s+\w*(KEY|TOKEN|SECRET|PASSWORD|CREDENTIAL)\w*`),
 		regexp.MustCompile(`--env\s+\w*(KEY|TOKEN|SECRET|PASSWORD|CREDENTIAL)\w*`),
 		regexp.MustCompile(`-e\s+\$\{\{\s*secrets\.\w+\s*\}\}`),
+		regexp.MustCompile(`-e\s+\w+=\$\{\{\s*secrets\.\w+\s*\}\}`),
 		regexp.MustCompile(`--env\s+\w+=\$\{\{\s*secrets\.\w+\s*\}\}`),
 	}
 
@@ -196,6 +208,19 @@ func checkDockerExecWithSecrets(workflow parser.WorkflowFile) []Finding {
 								hasSecretForward = true
 								break
 							}
+						}
+					}
+				}
+			}
+
+			if !hasSecretForward && step.Env != nil {
+				for key, value := range step.Env {
+					if strings.Contains(value, "secrets.") {
+						if strings.Contains(step.Run, "-e "+key) || strings.Contains(step.Run, "--env "+key) ||
+							strings.Contains(step.Run, "-e $"+key) || strings.Contains(step.Run, "--env $"+key) ||
+							strings.Contains(step.Run, "-e ${"+key+"}") || strings.Contains(step.Run, "--env ${"+key+"}") {
+							hasSecretForward = true
+							break
 						}
 					}
 				}
@@ -259,6 +284,11 @@ func checkIndirectDockerWithSecrets(workflow parser.WorkflowFile, lineMapper *li
 	}
 
 	for jobName, job := range workflow.Workflow.Jobs {
+		// Only flag if the job checks out untrusted PR head code
+		if !jobCheckoutsUntrustedCode(job) {
+			continue
+		}
+
 		for stepIdx, step := range job.Steps {
 			if step.Uses == "" {
 				continue

--- a/pkg/rules/docker_agent_exposure.go
+++ b/pkg/rules/docker_agent_exposure.go
@@ -95,22 +95,17 @@ func checkReusableWorkflowAgentExposure(workflow parser.WorkflowFile) []Finding 
 		}
 
 		if !hasSecrets {
-			contentStr := string(workflow.Content)
-			if strings.Contains(contentStr, "secrets:") {
-				hasSecrets = true
-			}
-		}
-
-		if !hasSecrets {
 			continue
 		}
 
 		severity := High
-		contentStr := string(workflow.Content)
-		if strings.Contains(contentStr, "PRIVATE_KEY") ||
-			strings.Contains(contentStr, "API_KEY") ||
-			strings.Contains(contentStr, "inherit") {
-			severity = Critical
+		if job.Secrets != nil {
+			switch s := job.Secrets.(type) {
+			case string:
+				if s == "inherit" {
+					severity = Critical
+				}
+			}
 		}
 
 		finding := Finding{
@@ -134,6 +129,7 @@ func checkReusableWorkflowAgentExposure(workflow parser.WorkflowFile) []Finding 
 
 // checkDockerExecWithSecrets detects direct docker run commands that forward
 // secrets via -e/--env while operating on fork code without network isolation.
+// Only flags when the job checks out untrusted PR head code.
 func checkDockerExecWithSecrets(workflow parser.WorkflowFile) []Finding {
 	var findings []Finding
 	lineMapper := linenum.NewLineMapper(workflow.Content)
@@ -154,6 +150,11 @@ func checkDockerExecWithSecrets(workflow parser.WorkflowFile) []Finding {
 	networkNone := regexp.MustCompile(`--network[=\s]+none`)
 
 	for jobName, job := range workflow.Workflow.Jobs {
+		// Only flag if the job checks out untrusted PR head code
+		if !jobCheckoutsUntrustedCode(job) {
+			continue
+		}
+
 		for stepIdx, step := range job.Steps {
 			if step.Run == "" {
 				continue
@@ -236,8 +237,10 @@ func checkDockerExecWithSecrets(workflow parser.WorkflowFile) []Finding {
 	return findings
 }
 
-// checkIndirectDockerWithSecrets detects step-level reusable workflow/action
-// calls that pass secrets to agent/review workflows under pull_request_target.
+// checkIndirectDockerWithSecrets detects step-level composite action calls
+// that pass secrets to agent/review workflows under pull_request_target.
+// Note: Reusable workflows (.github/workflows/) are job-level only;
+// step-level uses only valid for composite actions.
 func checkIndirectDockerWithSecrets(workflow parser.WorkflowFile, lineMapper *linenum.LineMapper) []Finding {
 	var findings []Finding
 
@@ -256,8 +259,8 @@ func checkIndirectDockerWithSecrets(workflow parser.WorkflowFile, lineMapper *li
 				continue
 			}
 
-			if !strings.Contains(step.Uses, ".github/workflows/") &&
-				!strings.Contains(step.Uses, ".github/actions/") {
+			// Step-level uses: only composite actions are valid here
+			if !strings.Contains(step.Uses, ".github/actions/") {
 				continue
 			}
 
@@ -353,6 +356,8 @@ func checkAIAgentOnUntrustedCode(workflow parser.WorkflowFile) []Finding {
 		regexp.MustCompile(`(?i)(anthropic|openai|claude|copilot).*action`),
 	}
 
+	networkNonePattern := regexp.MustCompile(`--network[=\s]+none`)
+
 	for jobName, job := range workflow.Workflow.Jobs {
 		for stepIdx, step := range job.Steps {
 			isAIStep := false
@@ -365,6 +370,10 @@ func checkAIAgentOnUntrustedCode(workflow parser.WorkflowFile) []Finding {
 						evidence = step.Run
 						break
 					}
+				}
+				// If this is a docker run with --network=none, it's mitigated
+				if isAIStep && networkNonePattern.MatchString(step.Run) {
+					continue
 				}
 			}
 
@@ -431,6 +440,15 @@ func checkAIAgentOnUntrustedCode(workflow parser.WorkflowFile) []Finding {
 				if lineResult != nil {
 					lineNumber = lineResult.LineNumber
 				}
+			} else if step.Uses != "" {
+				linePattern := linenum.FindPattern{
+					Key:   "uses",
+					Value: step.Uses,
+				}
+				lineResult := lineMapper.FindLineNumber(linePattern)
+				if lineResult != nil {
+					lineNumber = lineResult.LineNumber
+				}
 			}
 
 			finding := Finding{
@@ -444,6 +462,268 @@ func checkAIAgentOnUntrustedCode(workflow parser.WorkflowFile) []Finding {
 				StepName:    stepName,
 				Evidence:    evidence,
 				Remediation: "Add --network=none to agent containers. Treat all file contents as untrusted in agent prompts. Remove secrets from the agent environment if not needed. Require a maintainer label before running agents on fork PRs.",
+				LineNumber:  lineNumber,
+			}
+			findings = append(findings, finding)
+		}
+	}
+
+	return findings
+}
+
+// jobCheckoutsUntrustedCode returns true if a job contains a checkout step
+// that references the PR head (untrusted code). Checks for:
+// - actions/checkout with ref containing head.sha, head.ref, or head_ref
+// - git checkout/fetch commands referencing PR refs
+func jobCheckoutsUntrustedCode(job parser.Job) bool {
+	untrustedRefPatterns := []*regexp.Regexp{
+		regexp.MustCompile(`(?i)pull_request\.head\.sha`),
+		regexp.MustCompile(`(?i)pull_request\.head\.ref`),
+		regexp.MustCompile(`(?i)github\.head_ref`),
+		regexp.MustCompile(`(?i)event\.pull_request\.head`),
+		regexp.MustCompile(`(?i)refs/pull/`),
+	}
+
+	for _, step := range job.Steps {
+		// Check actions/checkout with untrusted ref
+		if strings.Contains(step.Uses, "actions/checkout") {
+			if step.With != nil {
+				if ref, ok := step.With["ref"]; ok {
+					refStr, _ := ref.(string)
+					for _, pattern := range untrustedRefPatterns {
+						if pattern.MatchString(refStr) {
+							return true
+						}
+					}
+				}
+			}
+		}
+
+		// Check run steps for git commands fetching PR refs
+		if step.Run != "" {
+			for _, pattern := range untrustedRefPatterns {
+				if pattern.MatchString(step.Run) {
+					return true
+				}
+			}
+		}
+	}
+
+	return false
+}
+
+// CheckAIAgentCommentTriggered detects AI agent workflows triggered by
+// issue_comment or pull_request_review_comment that process attacker-controlled
+// input (comment body) with secrets available. This enables prompt injection
+// attacks where any external user can @mention the agent and craft payloads
+// to exfiltrate secrets or abuse write permissions.
+func CheckAIAgentCommentTriggered(workflow parser.WorkflowFile) []Finding {
+	var findings []Finding
+
+	// Must be triggered by comment events
+	hasCommentTrigger := false
+	triggerName := ""
+	switch on := workflow.Workflow.On.(type) {
+	case map[string]interface{}:
+		if _, ok := on["issue_comment"]; ok {
+			hasCommentTrigger = true
+			triggerName = "issue_comment"
+		}
+		if _, ok := on["pull_request_review_comment"]; ok {
+			hasCommentTrigger = true
+			if triggerName != "" {
+				triggerName += " + pull_request_review_comment"
+			} else {
+				triggerName = "pull_request_review_comment"
+			}
+		}
+	}
+
+	if !hasCommentTrigger {
+		return findings
+	}
+
+	lineMapper := linenum.NewLineMapper(workflow.Content)
+
+	// Known AI agent actions (comment-triggered code review / chat agents)
+	aiAgentActions := []*regexp.Regexp{
+		regexp.MustCompile(`(?i)anthropics?/claude[-_]code[-_]action`),
+		regexp.MustCompile(`(?i)google[-_]gemini/code[-_]assist[-_]action`),
+		regexp.MustCompile(`(?i)github/copilot[-_]action`),
+		regexp.MustCompile(`(?i)openai/chatgpt[-_]action`),
+		regexp.MustCompile(`(?i)coderabbit`),
+		regexp.MustCompile(`(?i)sourcery[-_]ai`),
+		regexp.MustCompile(`(?i)sweep[-_]ai`),
+		regexp.MustCompile(`(?i)aider[-_]action`),
+		regexp.MustCompile(`(?i)devin[-_]action`),
+		regexp.MustCompile(`(?i)qodo/`),
+		regexp.MustCompile(`(?i)cursor[-_]action`),
+	}
+
+	// AI agent CLI patterns in run steps
+	aiRunPatterns := []*regexp.Regexp{
+		regexp.MustCompile(`(?i)\bclaude\s+(code|--prompt|-p)\b`),
+		regexp.MustCompile(`(?i)\bgemini\s+(run|review|respond)\b`),
+		regexp.MustCompile(`(?i)\baider\b.*\b(run|--message)\b`),
+		regexp.MustCompile(`(?i)\bcody\b.*\b(chat|respond)\b`),
+		regexp.MustCompile(`(?i)\bcopilot\b.*\b(review|respond)\b`),
+	}
+
+	for jobName, job := range workflow.Workflow.Jobs {
+		for stepIdx, step := range job.Steps {
+			isAIAgent := false
+			evidence := ""
+
+			// Check uses: for known AI agent actions
+			if step.Uses != "" {
+				for _, pattern := range aiAgentActions {
+					if pattern.MatchString(step.Uses) {
+						isAIAgent = true
+						evidence = "uses: " + step.Uses
+						break
+					}
+				}
+			}
+
+			// Check run: for AI CLI invocations
+			if !isAIAgent && step.Run != "" {
+				for _, pattern := range aiRunPatterns {
+					if pattern.MatchString(step.Run) {
+						isAIAgent = true
+						evidence = step.Run
+						break
+					}
+				}
+			}
+
+			if !isAIAgent {
+				continue
+			}
+
+			// Check if author_association is already gated
+			hasActorGate := false
+			if job.If != "" {
+				if strings.Contains(job.If, "author_association") {
+					hasActorGate = true
+				}
+			}
+			if step.If != "" {
+				if strings.Contains(step.If, "author_association") {
+					hasActorGate = true
+				}
+			}
+			// Also check the job-level if from raw content for complex expressions
+			contentStr := string(workflow.Content)
+			if strings.Contains(contentStr, "author_association") &&
+				(strings.Contains(contentStr, "'MEMBER'") || strings.Contains(contentStr, "'OWNER'") || strings.Contains(contentStr, "'COLLABORATOR'")) {
+				hasActorGate = true
+			}
+
+			if hasActorGate {
+				continue
+			}
+
+			// Determine what secrets are exposed
+			hasSecrets := false
+			secretEvidence := []string{}
+
+			if step.With != nil {
+				for key, value := range step.With {
+					if valueStr, ok := value.(string); ok {
+						if strings.Contains(valueStr, "secrets.") {
+							hasSecrets = true
+							secretEvidence = append(secretEvidence, key+"="+valueStr)
+						}
+					}
+				}
+			}
+
+			if step.Env != nil {
+				for key, value := range step.Env {
+					if strings.Contains(value, "secrets.") {
+						hasSecrets = true
+						secretEvidence = append(secretEvidence, key+"="+value)
+					}
+				}
+			}
+
+			if job.Env != nil {
+				for _, value := range job.Env {
+					if strings.Contains(value, "secrets.") {
+						hasSecrets = true
+						break
+					}
+				}
+			}
+
+			stepName := step.Name
+			if stepName == "" {
+				stepName = "Step " + string(rune('1'+stepIdx))
+			}
+
+			lineNumber := 1
+			if step.Uses != "" {
+				linePattern := linenum.FindPattern{
+					Key:   "uses",
+					Value: step.Uses,
+				}
+				lineResult := lineMapper.FindLineNumber(linePattern)
+				if lineResult != nil {
+					lineNumber = lineResult.LineNumber
+				}
+			} else if step.Run != "" {
+				linePattern := linenum.FindPattern{
+					Key:   "run",
+					Value: step.Run,
+				}
+				lineResult := lineMapper.FindLineNumber(linePattern)
+				if lineResult != nil {
+					lineNumber = lineResult.LineNumber
+				}
+			}
+
+			// Determine severity and description based on exposure
+			var severity Severity
+			var description string
+			var ruleCategory Category
+
+			if hasSecrets {
+				ruleCategory = SecretExposure
+				severity = High
+				// If the job has write permissions, severity is Critical
+				if job.Permissions != nil && permsImplyWrite(job.Permissions) {
+					severity = Critical
+				}
+				secretInfo := ""
+				if len(secretEvidence) > 0 {
+					secretInfo = " Secrets passed: " + strings.Join(secretEvidence, ", ")
+				}
+				description = "A workflow runs an AI agent in response to issue comments or PR review comments " +
+					"without restricting to trusted actors (author_association). " +
+					"Any user who can comment (including external contributors on public repos) can trigger the agent " +
+					"and control its input via the comment body. With secrets available, an attacker can craft prompt " +
+					"injection payloads to exfiltrate API keys or abuse write permissions." + secretInfo
+			} else {
+				// Denial-of-wallet: no secrets but still burns API credits
+				ruleCategory = AccessControl
+				severity = Medium
+				description = "A workflow runs an AI agent in response to issue comments or PR review comments " +
+					"without restricting to trusted actors (author_association). " +
+					"Any user who can comment on public repos can trigger the agent, causing unbounded API cost. " +
+					"An attacker can spam mentions to inflict denial-of-wallet by exhausting the API budget."
+			}
+
+			finding := Finding{
+				RuleID:      "AI_AGENT_COMMENT_TRIGGERED",
+				RuleName:    "AI Agent Triggered by External Comment Without Actor Gate",
+				Description: description,
+				Severity:    severity,
+				Category:    ruleCategory,
+				FilePath:    workflow.Path,
+				JobName:     jobName,
+				StepName:    stepName,
+				Evidence:    evidence,
+				Remediation: "Restrict trigger to trusted actors: add `if: github.event.comment.author_association == 'MEMBER' || github.event.comment.author_association == 'OWNER'`. For cost control, add rate limiting or require a maintainer label. Never pass secrets directly to agent actions processing external input.",
 				LineNumber:  lineNumber,
 			}
 			findings = append(findings, finding)

--- a/pkg/rules/docker_agent_exposure.go
+++ b/pkg/rules/docker_agent_exposure.go
@@ -290,9 +290,14 @@ func checkIndirectDockerWithSecrets(workflow parser.WorkflowFile, lineMapper *li
 			}
 
 			if !hasSecrets {
-				contentStr := string(workflow.Content)
-				if strings.Contains(contentStr, "secrets: inherit") {
-					hasSecrets = true
+				// Check job-level secrets field (for reusable workflow calls in same job)
+				if job.Secrets != nil {
+					switch s := job.Secrets.(type) {
+					case string:
+						if s == "inherit" {
+							hasSecrets = true
+						}
+					}
 				}
 			}
 
@@ -303,6 +308,18 @@ func checkIndirectDockerWithSecrets(workflow parser.WorkflowFile, lineMapper *li
 			stepName := step.Name
 			if stepName == "" {
 				stepName = "Step " + string(rune('1'+stepIdx))
+			}
+
+			lineNumber := 1
+			if step.Uses != "" {
+				linePattern := linenum.FindPattern{
+					Key:   "uses",
+					Value: step.Uses,
+				}
+				lineResult := lineMapper.FindLineNumber(linePattern)
+				if lineResult != nil {
+					lineNumber = lineResult.LineNumber
+				}
 			}
 
 			finding := Finding{
@@ -316,7 +333,7 @@ func checkIndirectDockerWithSecrets(workflow parser.WorkflowFile, lineMapper *li
 				StepName:    stepName,
 				Evidence:    "uses: " + step.Uses,
 				Remediation: "Audit the reusable workflow to ensure Docker containers use --network=none and secrets are not forwarded into containers processing fork code.",
-				LineNumber:  1,
+				LineNumber:  lineNumber,
 			}
 			findings = append(findings, finding)
 		}
@@ -359,6 +376,11 @@ func checkAIAgentOnUntrustedCode(workflow parser.WorkflowFile) []Finding {
 	networkNonePattern := regexp.MustCompile(`--network[=\s]+none`)
 
 	for jobName, job := range workflow.Workflow.Jobs {
+		// Only flag if the job checks out untrusted PR head code
+		if !jobCheckoutsUntrustedCode(job) {
+			continue
+		}
+
 		for stepIdx, step := range job.Steps {
 			isAIStep := false
 			evidence := ""
@@ -522,20 +544,13 @@ func CheckAIAgentCommentTriggered(workflow parser.WorkflowFile) []Finding {
 
 	// Must be triggered by comment events
 	hasCommentTrigger := false
-	triggerName := ""
 	switch on := workflow.Workflow.On.(type) {
 	case map[string]interface{}:
 		if _, ok := on["issue_comment"]; ok {
 			hasCommentTrigger = true
-			triggerName = "issue_comment"
 		}
 		if _, ok := on["pull_request_review_comment"]; ok {
 			hasCommentTrigger = true
-			if triggerName != "" {
-				triggerName += " + pull_request_review_comment"
-			} else {
-				triggerName = "pull_request_review_comment"
-			}
 		}
 	}
 
@@ -600,22 +615,13 @@ func CheckAIAgentCommentTriggered(workflow parser.WorkflowFile) []Finding {
 				continue
 			}
 
-			// Check if author_association is already gated
+			// Check if author_association is already gated to trusted actors
 			hasActorGate := false
-			if job.If != "" {
-				if strings.Contains(job.If, "author_association") {
-					hasActorGate = true
-				}
+			actorGatePattern := regexp.MustCompile(`author_association\s*==\s*'(MEMBER|OWNER|COLLABORATOR)'`)
+			if job.If != "" && actorGatePattern.MatchString(job.If) {
+				hasActorGate = true
 			}
-			if step.If != "" {
-				if strings.Contains(step.If, "author_association") {
-					hasActorGate = true
-				}
-			}
-			// Also check the job-level if from raw content for complex expressions
-			contentStr := string(workflow.Content)
-			if strings.Contains(contentStr, "author_association") &&
-				(strings.Contains(contentStr, "'MEMBER'") || strings.Contains(contentStr, "'OWNER'") || strings.Contains(contentStr, "'COLLABORATOR'")) {
+			if step.If != "" && actorGatePattern.MatchString(step.If) {
 				hasActorGate = true
 			}
 
@@ -690,8 +696,13 @@ func CheckAIAgentCommentTriggered(workflow parser.WorkflowFile) []Finding {
 			if hasSecrets {
 				ruleCategory = SecretExposure
 				severity = High
-				// If the job has write permissions, severity is Critical
-				if job.Permissions != nil && permsImplyWrite(job.Permissions) {
+				// If the job effectively has write permissions, severity is Critical.
+				// Job-level permissions inherit from workflow-level when nil.
+				effectivePermissions := job.Permissions
+				if effectivePermissions == nil {
+					effectivePermissions = workflow.Workflow.Permissions
+				}
+				if permsImplyWrite(effectivePermissions) {
 					severity = Critical
 				}
 				secretInfo := ""

--- a/pkg/rules/docker_agent_exposure.go
+++ b/pkg/rules/docker_agent_exposure.go
@@ -469,8 +469,7 @@ func checkAIAgentOnUntrustedCode(workflow parser.WorkflowFile) []Finding {
 			}
 			if !hasSecrets && step.Env != nil {
 				for _, value := range step.Env {
-					if strings.Contains(strings.ToUpper(value), "KEY") ||
-						strings.Contains(strings.ToUpper(value), "TOKEN") {
+					if strings.Contains(value, "secrets.") {
 						hasSecrets = true
 						break
 					}

--- a/pkg/rules/docker_agent_exposure.go
+++ b/pkg/rules/docker_agent_exposure.go
@@ -98,12 +98,12 @@ func checkReusableWorkflowAgentExposure(workflow parser.WorkflowFile) []Finding 
 			continue
 		}
 
-		severity := High
+		severity := Medium
 		if job.Secrets != nil {
 			switch s := job.Secrets.(type) {
 			case string:
 				if s == "inherit" {
-					severity = Critical
+					severity = High
 				}
 			}
 		}
@@ -111,7 +111,7 @@ func checkReusableWorkflowAgentExposure(workflow parser.WorkflowFile) []Finding 
 		finding := Finding{
 			RuleID:      "DOCKER_EXEC_WITH_SECRETS_ON_FORK_CODE",
 			RuleName:    "Reusable Agent Workflow Called With Secrets on pull_request_target",
-			Description: "A pull_request_target workflow calls a reusable workflow that runs an AI agent or automated review, passing secrets including API keys or private keys. The downstream workflow checks out fork code and processes it in a container with these secrets available, enabling secret exfiltration by external attackers.",
+			Description: "A pull_request_target workflow calls a reusable workflow that appears to run an AI agent or automated review, passing secrets. Verify whether the called workflow checks out the PR head ref — if it does, fork code runs in a container with secrets available, enabling exfiltration.",
 			Severity:    severity,
 			Category:    SecretExposure,
 			FilePath:    workflow.Path,
@@ -189,8 +189,13 @@ func checkDockerExecWithSecrets(workflow parser.WorkflowFile) []Finding {
 						keyUpper := strings.ToUpper(key)
 						if strings.Contains(keyUpper, "KEY") || strings.Contains(keyUpper, "TOKEN") ||
 							strings.Contains(keyUpper, "SECRET") || strings.Contains(keyUpper, "PASSWORD") {
-							hasSecretForward = true
-							break
+							// Only flag if the docker run command actually forwards this env var
+							if strings.Contains(step.Run, "-e "+key) || strings.Contains(step.Run, "--env "+key) ||
+								strings.Contains(step.Run, "-e $"+key) || strings.Contains(step.Run, "--env $"+key) ||
+								strings.Contains(step.Run, "-e ${"+key+"}") || strings.Contains(step.Run, "--env ${"+key+"}") {
+								hasSecretForward = true
+								break
+							}
 						}
 					}
 				}
@@ -545,6 +550,19 @@ func CheckAIAgentCommentTriggered(workflow parser.WorkflowFile) []Finding {
 	// Must be triggered by comment events
 	hasCommentTrigger := false
 	switch on := workflow.Workflow.On.(type) {
+	case string:
+		if on == "issue_comment" || on == "pull_request_review_comment" {
+			hasCommentTrigger = true
+		}
+	case []interface{}:
+		for _, trigger := range on {
+			if t, ok := trigger.(string); ok {
+				if t == "issue_comment" || t == "pull_request_review_comment" {
+					hasCommentTrigger = true
+					break
+				}
+			}
+		}
 	case map[string]interface{}:
 		if _, ok := on["issue_comment"]; ok {
 			hasCommentTrigger = true

--- a/pkg/rules/docker_agent_exposure_test.go
+++ b/pkg/rules/docker_agent_exposure_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package rules
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/harekrishnarai/flowlyt/pkg/parser"
@@ -191,11 +192,8 @@ jobs:
 			},
 			Jobs: map[string]parser.Job{
 				"review": {
-					Steps: []parser.Step{
-						{
-							Uses: "org/reusable-workflows/.github/workflows/review-pull-request.yml@main",
-						},
-					},
+					Uses:    "org/reusable-workflows/.github/workflows/review-pull-request.yml@main",
+					Secrets: "inherit",
 				},
 			},
 		},
@@ -267,5 +265,224 @@ jobs:
 	}
 	if !found {
 		t.Error("Expected AI_AGENT_ON_UNTRUSTED_CODE finding for oz-agent-action with secrets")
+	}
+}
+
+func TestCheckAIAgentCommentTriggered_ClaudeCodeAction(t *testing.T) {
+	workflow := parser.WorkflowFile{
+		Path: ".github/workflows/claude-mention.yml",
+		Content: []byte(`name: Claude Code Mention
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+jobs:
+  claude:
+    runs-on: ubuntu-latest
+    if: contains(github.event.comment.body, '@claude')
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: write
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+      - uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+`),
+		Workflow: parser.Workflow{
+			On: map[string]interface{}{
+				"issue_comment": map[string]interface{}{
+					"types": []interface{}{"created"},
+				},
+				"pull_request_review_comment": map[string]interface{}{
+					"types": []interface{}{"created"},
+				},
+			},
+			Jobs: map[string]parser.Job{
+				"claude": {
+					Permissions: map[string]interface{}{
+						"contents":      "read",
+						"pull-requests": "write",
+						"issues":        "write",
+						"id-token":      "write",
+					},
+					Steps: []parser.Step{
+						{
+							Uses: "actions/checkout@v4",
+							With: map[string]interface{}{
+								"fetch-depth": "1",
+							},
+						},
+						{
+							Uses: "anthropics/claude-code-action@v1",
+							With: map[string]interface{}{
+								"anthropic_api_key": "${{ secrets.ANTHROPIC_API_KEY }}",
+								"github_token":      "${{ secrets.GITHUB_TOKEN }}",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	findings := CheckAIAgentCommentTriggered(workflow)
+
+	if len(findings) == 0 {
+		t.Fatal("Expected finding for comment-triggered AI agent with secrets")
+	}
+
+	f := findings[0]
+	if f.RuleID != "AI_AGENT_COMMENT_TRIGGERED" {
+		t.Errorf("Expected AI_AGENT_COMMENT_TRIGGERED, got %s", f.RuleID)
+	}
+	if f.Severity != Critical {
+		t.Errorf("Expected Critical severity (has write permissions), got %v", f.Severity)
+	}
+	if !strings.Contains(f.Description, "secrets") {
+		t.Error("Description should mention secrets")
+	}
+}
+
+func TestCheckAIAgentCommentTriggered_NoSecrets(t *testing.T) {
+	workflow := parser.WorkflowFile{
+		Path: ".github/workflows/claude-mention.yml",
+		Content: []byte(`name: Claude Code Mention
+on:
+  issue_comment:
+    types: [created]
+jobs:
+  claude:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: anthropics/claude-code-action@v1
+        with:
+          model: claude-sonnet
+`),
+		Workflow: parser.Workflow{
+			On: map[string]interface{}{
+				"issue_comment": map[string]interface{}{
+					"types": []interface{}{"created"},
+				},
+			},
+			Jobs: map[string]parser.Job{
+				"claude": {
+					Steps: []parser.Step{
+						{
+							Uses: "anthropics/claude-code-action@v1",
+							With: map[string]interface{}{
+								"model": "claude-sonnet",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	findings := CheckAIAgentCommentTriggered(workflow)
+
+	if len(findings) == 0 {
+		t.Fatal("Expected denial-of-wallet finding even without secrets")
+	}
+	if findings[0].Severity != Medium {
+		t.Errorf("Expected Medium severity for denial-of-wallet, got %v", findings[0].Severity)
+	}
+	if !strings.Contains(findings[0].Description, "denial-of-wallet") {
+		t.Error("Description should mention denial-of-wallet")
+	}
+}
+
+func TestCheckAIAgentCommentTriggered_NotCommentTrigger(t *testing.T) {
+	workflow := parser.WorkflowFile{
+		Path: ".github/workflows/claude-pr.yml",
+		Content: []byte(`name: Claude on PR
+on:
+  pull_request:
+    types: [opened]
+jobs:
+  claude:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+`),
+		Workflow: parser.Workflow{
+			On: map[string]interface{}{
+				"pull_request": map[string]interface{}{
+					"types": []interface{}{"opened"},
+				},
+			},
+			Jobs: map[string]parser.Job{
+				"claude": {
+					Steps: []parser.Step{
+						{
+							Uses: "anthropics/claude-code-action@v1",
+							With: map[string]interface{}{
+								"anthropic_api_key": "${{ secrets.ANTHROPIC_API_KEY }}",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	findings := CheckAIAgentCommentTriggered(workflow)
+
+	if len(findings) != 0 {
+		t.Errorf("Expected no findings for non-comment trigger, got %d", len(findings))
+	}
+}
+
+func TestCheckAIAgentCommentTriggered_AuthorAssociationGate(t *testing.T) {
+	workflow := parser.WorkflowFile{
+		Path: ".github/workflows/claude-mention.yml",
+		Content: []byte(`name: Claude Code Mention
+on:
+  issue_comment:
+    types: [created]
+jobs:
+  claude:
+    runs-on: ubuntu-latest
+    if: github.event.comment.author_association == 'MEMBER'
+    steps:
+      - uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+`),
+		Workflow: parser.Workflow{
+			On: map[string]interface{}{
+				"issue_comment": map[string]interface{}{
+					"types": []interface{}{"created"},
+				},
+			},
+			Jobs: map[string]parser.Job{
+				"claude": {
+					If: "github.event.comment.author_association == 'MEMBER'",
+					Steps: []parser.Step{
+						{
+							Uses: "anthropics/claude-code-action@v1",
+							With: map[string]interface{}{
+								"anthropic_api_key": "${{ secrets.ANTHROPIC_API_KEY }}",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	findings := CheckAIAgentCommentTriggered(workflow)
+
+	if len(findings) != 0 {
+		t.Errorf("Expected no findings when author_association gate is present, got %d", len(findings))
 	}
 }

--- a/pkg/rules/docker_agent_exposure_test.go
+++ b/pkg/rules/docker_agent_exposure_test.go
@@ -1,0 +1,271 @@
+/*
+Copyright 2025 Hare Krishna Rai
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package rules
+
+import (
+	"testing"
+
+	"github.com/harekrishnarai/flowlyt/pkg/parser"
+)
+
+func TestCheckDockerExecWithSecrets_DirectDockerRun(t *testing.T) {
+	workflow := parser.WorkflowFile{
+		Path: ".github/workflows/review.yml",
+		Content: []byte(`name: Review PR
+on:
+  pull_request_target:
+    types: [opened]
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+      - name: Run review agent
+        run: |
+          docker run --rm -e VENDOR_API_KEY -e VENDOR_API_BASE_URL -v $PWD:/mnt/repo:ro my-agent:latest agent run --skill review-pr --cwd /mnt/repo
+`),
+		Workflow: parser.Workflow{
+			On: map[string]interface{}{
+				"pull_request_target": map[string]interface{}{
+					"types": []interface{}{"opened"},
+				},
+			},
+			Jobs: map[string]parser.Job{
+				"review": {
+					Steps: []parser.Step{
+						{
+							Uses: "actions/checkout@v4",
+							With: map[string]interface{}{
+								"ref": "${{ github.event.pull_request.head.sha }}",
+							},
+						},
+						{
+							Name: "Run review agent",
+							Run:  "docker run --rm -e VENDOR_API_KEY -e VENDOR_API_BASE_URL -v $PWD:/mnt/repo:ro my-agent:latest agent run --skill review-pr --cwd /mnt/repo",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	findings := CheckDockerAgentExposure(workflow)
+	// Also run the AI agent check independently (as it would be from StandardRules)
+	findings = append(findings, checkAIAgentOnUntrustedCode(workflow)...)
+
+	if len(findings) == 0 {
+		t.Fatal("Expected findings for docker run with secrets on fork code, got none")
+	}
+
+	foundDocker := false
+	foundAI := false
+	for _, f := range findings {
+		if f.RuleID == "DOCKER_EXEC_WITH_SECRETS_ON_FORK_CODE" {
+			foundDocker = true
+			if f.Severity != Critical {
+				t.Errorf("Expected Critical severity, got %s", f.Severity)
+			}
+		}
+		if f.RuleID == "AI_AGENT_ON_UNTRUSTED_CODE" {
+			foundAI = true
+		}
+	}
+
+	if !foundDocker {
+		t.Error("Expected DOCKER_EXEC_WITH_SECRETS_ON_FORK_CODE finding")
+	}
+	if !foundAI {
+		t.Error("Expected AI_AGENT_ON_UNTRUSTED_CODE finding (docker run with agent keyword)")
+	}
+}
+
+func TestCheckDockerExecWithSecrets_NetworkNoneMitigates(t *testing.T) {
+	workflow := parser.WorkflowFile{
+		Path: ".github/workflows/review.yml",
+		Content: []byte(`name: Review PR
+on:
+  pull_request_target:
+    types: [opened]
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Run review agent
+        run: |
+          docker run --rm --network=none -e VENDOR_API_KEY -v $PWD:/mnt/repo:ro my-agent:latest
+`),
+		Workflow: parser.Workflow{
+			On: map[string]interface{}{
+				"pull_request_target": map[string]interface{}{
+					"types": []interface{}{"opened"},
+				},
+			},
+			Jobs: map[string]parser.Job{
+				"review": {
+					Steps: []parser.Step{
+						{
+							Name: "Run review agent",
+							Run:  "docker run --rm --network=none -e VENDOR_API_KEY -v $PWD:/mnt/repo:ro my-agent:latest",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	findings := CheckDockerAgentExposure(workflow)
+
+	for _, f := range findings {
+		if f.RuleID == "DOCKER_EXEC_WITH_SECRETS_ON_FORK_CODE" {
+			t.Error("Should NOT flag docker run with --network=none (exfiltration mitigated)")
+		}
+	}
+}
+
+func TestCheckDockerExecWithSecrets_NoPRTargetNoFinding(t *testing.T) {
+	workflow := parser.WorkflowFile{
+		Path: ".github/workflows/ci.yml",
+		Content: []byte(`name: CI
+on: push
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Run agent
+        run: docker run --rm -e SECRET_KEY my-agent:latest
+`),
+		Workflow: parser.Workflow{
+			On: "push",
+			Jobs: map[string]parser.Job{
+				"build": {
+					Steps: []parser.Step{
+						{
+							Name: "Run agent",
+							Run:  "docker run --rm -e SECRET_KEY my-agent:latest",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	findings := CheckDockerAgentExposure(workflow)
+	if len(findings) != 0 {
+		t.Errorf("Expected no findings for non-pull_request_target workflow, got %d", len(findings))
+	}
+}
+
+func TestCheckAIAgentOnUntrustedCode_ReusableWorkflow(t *testing.T) {
+	workflow := parser.WorkflowFile{
+		Path: ".github/workflows/review-pull-request.yml",
+		Content: []byte(`name: Review
+on:
+  pull_request_target:
+    types: [opened]
+jobs:
+  review:
+    uses: org/reusable-workflows/.github/workflows/review-pull-request.yml@main
+    secrets: inherit
+`),
+		Workflow: parser.Workflow{
+			On: map[string]interface{}{
+				"pull_request_target": map[string]interface{}{
+					"types": []interface{}{"opened"},
+				},
+			},
+			Jobs: map[string]parser.Job{
+				"review": {
+					Steps: []parser.Step{
+						{
+							Uses: "org/reusable-workflows/.github/workflows/review-pull-request.yml@main",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	findings := CheckDockerAgentExposure(workflow)
+
+	found := false
+	for _, f := range findings {
+		if f.RuleID == "DOCKER_EXEC_WITH_SECRETS_ON_FORK_CODE" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("Expected finding for reusable review workflow with secrets:inherit")
+	}
+}
+
+func TestCheckAIAgentOnUntrustedCode_OzAgentAction(t *testing.T) {
+	workflow := parser.WorkflowFile{
+		Path: ".github/workflows/review.yml",
+		Content: []byte(`name: Review
+on:
+  pull_request_target:
+    types: [opened]
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    steps:
+      - name: AI Code Review
+        uses: org/oz-agent-action@main
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+`),
+		Workflow: parser.Workflow{
+			On: map[string]interface{}{
+				"pull_request_target": map[string]interface{}{
+					"types": []interface{}{"opened"},
+				},
+			},
+			Jobs: map[string]parser.Job{
+				"review": {
+					Steps: []parser.Step{
+						{
+							Name: "AI Code Review",
+							Uses: "org/oz-agent-action@main",
+							With: map[string]interface{}{
+								"token": "${{ secrets.GITHUB_TOKEN }}",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	findings := checkAIAgentOnUntrustedCode(workflow)
+
+	found := false
+	for _, f := range findings {
+		if f.RuleID == "AI_AGENT_ON_UNTRUSTED_CODE" {
+			found = true
+			if f.Severity != High {
+				t.Errorf("Expected High severity, got %s", f.Severity)
+			}
+			break
+		}
+	}
+	if !found {
+		t.Error("Expected AI_AGENT_ON_UNTRUSTED_CODE finding for oz-agent-action with secrets")
+	}
+}

--- a/pkg/rules/docker_agent_exposure_test.go
+++ b/pkg/rules/docker_agent_exposure_test.go
@@ -224,6 +224,9 @@ jobs:
   review:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
       - name: AI Code Review
         uses: org/oz-agent-action@main
         with:
@@ -238,6 +241,12 @@ jobs:
 			Jobs: map[string]parser.Job{
 				"review": {
 					Steps: []parser.Step{
+						{
+							Uses: "actions/checkout@v4",
+							With: map[string]interface{}{
+								"ref": "${{ github.event.pull_request.head.sha }}",
+							},
+						},
 						{
 							Name: "AI Code Review",
 							Uses: "org/oz-agent-action@main",

--- a/pkg/rules/rules.go
+++ b/pkg/rules/rules.go
@@ -683,6 +683,15 @@ func StandardRules() []Rule {
 			Platform:    PlatformGitHub,
 			Check:       checkAIAgentOnUntrustedCode,
 		},
+		{
+			ID:          "AI_AGENT_COMMENT_TRIGGERED",
+			Name:        "AI Agent Triggered by External Comment Without Actor Gate",
+			Description: "An AI agent runs in response to issue/PR comments from any user without author_association gating, enabling prompt injection (with secrets) or denial-of-wallet (without secrets) attacks",
+			Severity:    High,
+			Category:    SecretExposure,
+			Platform:    PlatformGitHub,
+			Check:       CheckAIAgentCommentTriggered,
+		},
 	}
 }
 
@@ -3250,15 +3259,15 @@ func checkExternalTrigger(workflow parser.WorkflowFile) []Finding {
 	}
 
 	// Check for dangerous external triggers
-	// Only flag triggers that combine external accessibility with write permissions,
-	// since read-only workflows triggered externally pose minimal risk.
+	// pull_request_target is always dangerous (elevated permissions on fork code).
+	// Other triggers are only flagged when the workflow has write permissions.
 	dangerousTriggers := map[string]string{
 		"pull_request_target": "Can be triggered by external pull requests with elevated permissions",
-		"issue_comment":       "Can be triggered by anyone who can comment on issues",
 	}
 
 	// These triggers are only concerning when the workflow has write permissions
 	writeRequiredTriggers := map[string]string{
+		"issue_comment":       "Can be triggered by anyone who can comment on issues",
 		"workflow_run":        "Can be triggered by completion of other workflows",
 		"repository_dispatch": "Can be triggered via API by repository collaborators",
 		"workflow_dispatch":   "Can be manually triggered with potential for abuse",

--- a/pkg/rules/rules.go
+++ b/pkg/rules/rules.go
@@ -1982,6 +1982,8 @@ func CheckAllRules(workflow parser.WorkflowFile) []Finding {
 
 	// Phase 4: Docker agent exposure (AI agents on fork code with secrets)
 	findings = append(findings, CheckDockerAgentExposure(workflow)...)
+	findings = append(findings, checkAIAgentOnUntrustedCode(workflow)...)
+	findings = append(findings, CheckAIAgentCommentTriggered(workflow)...)
 
 	return findings
 }

--- a/pkg/rules/rules.go
+++ b/pkg/rules/rules.go
@@ -665,6 +665,24 @@ func StandardRules() []Rule {
 			Platform:    PlatformAll,
 			Check:       checkIndirectPPEBuildTool,
 		},
+		{
+			ID:          "DOCKER_EXEC_WITH_SECRETS_ON_FORK_CODE",
+			Name:        "Docker Container Runs Fork Code With Secrets (No Network Isolation)",
+			Description: "A pull_request_target workflow runs a Docker container or reusable agent workflow with secrets forwarded while processing fork code without network isolation",
+			Severity:    Critical,
+			Category:    SecretExposure,
+			Platform:    PlatformGitHub,
+			Check:       CheckDockerAgentExposure,
+		},
+		{
+			ID:          "AI_AGENT_ON_UNTRUSTED_CODE",
+			Name:        "AI Agent Processes Untrusted Fork Code With Secrets",
+			Description: "An AI agent/bot processes fork-controlled code in a pull_request_target workflow with secrets available, enabling indirect prompt injection to exfiltrate secrets",
+			Severity:    High,
+			Category:    SecretExposure,
+			Platform:    PlatformGitHub,
+			Check:       checkAIAgentOnUntrustedCode,
+		},
 	}
 }
 
@@ -1953,6 +1971,9 @@ func CheckAllRules(workflow parser.WorkflowFile) []Finding {
 	findings = append(findings, CheckSelfHostedRunnerSecurity(workflow)...)
 	findings = append(findings, CheckAdvancedPrivilegeAnalysis(workflow)...)
 
+	// Phase 4: Docker agent exposure (AI agents on fork code with secrets)
+	findings = append(findings, CheckDockerAgentExposure(workflow)...)
+
 	return findings
 }
 
@@ -1963,16 +1984,14 @@ func checkDangerousWriteOperations(workflow parser.WorkflowFile) []Finding {
 
 	lineMapper := linenum.NewLineMapper(workflow.Content)
 
-	// Patterns that indicate dangerous writes to GitHub environment variables
+	// Patterns that indicate dangerous writes to GitHub environment variables.
+	// Only flag expression interpolation (${{ ... }}) which can contain attacker-controlled
+	// values from PR titles, branch names, issue bodies, etc.
 	dangerousPatterns := []*regexp.Regexp{
-		// Only flag patterns with user input that could be dangerous
-		regexp.MustCompile(`echo\s+.*\$\{\{[^}]*\}\}.*>>\s*\$GITHUB_OUTPUT`),   // Echo with user input to GITHUB_OUTPUT
-		regexp.MustCompile(`echo\s+.*\$\{\{[^}]*\}\}.*>>\s*\$GITHUB_ENV`),      // Echo with user input to GITHUB_ENV
-		regexp.MustCompile(`printf\s+.*\$\{\{[^}]*\}\}.*>>\s*\$GITHUB_OUTPUT`), // Printf with user input to GITHUB_OUTPUT
-		regexp.MustCompile(`printf\s+.*\$\{\{[^}]*\}\}.*>>\s*\$GITHUB_ENV`),    // Printf with user input to GITHUB_ENV
-		// Flag variables that might contain user input
-		regexp.MustCompile(`echo\s+.*\$[A-Z_]+.*>>\s*\$GITHUB_OUTPUT`), // Echo variable to GITHUB_OUTPUT
-		regexp.MustCompile(`echo\s+.*\$[A-Z_]+.*>>\s*\$GITHUB_ENV`),    // Echo variable to GITHUB_ENV
+		regexp.MustCompile(`echo\s+.*\$\{\{[^}]*\}\}.*>>\s*\$GITHUB_OUTPUT`),
+		regexp.MustCompile(`echo\s+.*\$\{\{[^}]*\}\}.*>>\s*\$GITHUB_ENV`),
+		regexp.MustCompile(`printf\s+.*\$\{\{[^}]*\}\}.*>>\s*\$GITHUB_OUTPUT`),
+		regexp.MustCompile(`printf\s+.*\$\{\{[^}]*\}\}.*>>\s*\$GITHUB_ENV`),
 	}
 
 	for jobName, job := range workflow.Workflow.Jobs {
@@ -3231,19 +3250,22 @@ func checkExternalTrigger(workflow parser.WorkflowFile) []Finding {
 	}
 
 	// Check for dangerous external triggers
+	// Only flag triggers that combine external accessibility with write permissions,
+	// since read-only workflows triggered externally pose minimal risk.
 	dangerousTriggers := map[string]string{
-		"issue_comment":       "Can be triggered by anyone who can comment on issues",
 		"pull_request_target": "Can be triggered by external pull requests with elevated permissions",
-		"workflow_run":        "Can be triggered by completion of other workflows",
-		"repository_dispatch": "Can be triggered via API by repository collaborators",
+		"issue_comment":       "Can be triggered by anyone who can comment on issues",
 	}
 
-	// workflow_dispatch is only concerning in certain contexts
-	workflowDispatchTriggers := map[string]string{
-		"workflow_dispatch": "Can be manually triggered with potential for abuse",
+	// These triggers are only concerning when the workflow has write permissions
+	writeRequiredTriggers := map[string]string{
+		"workflow_run":        "Can be triggered by completion of other workflows",
+		"repository_dispatch": "Can be triggered via API by repository collaborators",
+		"workflow_dispatch":   "Can be manually triggered with potential for abuse",
 	}
 
 	for _, trigger := range triggerEvents {
+		// pull_request_target is always dangerous — elevated permissions on fork code
 		if risk, isDangerous := dangerousTriggers[trigger]; isDangerous {
 			lineResult := lineMapper.FindLineNumber(linenum.FindPattern{
 				Key:   "on",
@@ -3268,15 +3290,11 @@ func checkExternalTrigger(workflow parser.WorkflowFile) []Finding {
 			})
 		}
 
-		// workflow_dispatch: only flag when the workflow has effective write
-		// permissions. A read-only workflow_dispatch poses no meaningful risk.
-		if risk, isWorkflowDispatch := workflowDispatchTriggers[trigger]; isWorkflowDispatch {
-			// Check workflow-level permissions first, then any job-level permissions.
+		// Other external triggers: only flag when the workflow has effective write
+		// permissions. A read-only workflow with these triggers poses minimal risk.
+		if risk, isWriteRequired := writeRequiredTriggers[trigger]; isWriteRequired {
 			workflowHasWrite := permsImplyWrite(workflow.Workflow.Permissions)
 			if !workflowHasWrite {
-				// Check if any job explicitly grants write permissions.
-				// A nil job.Permissions means "inherit from workflow" — skip it;
-				// only an explicit job-level block can upgrade permissions.
 				for _, job := range workflow.Workflow.Jobs {
 					if job.Permissions != nil && permsImplyWrite(job.Permissions) {
 						workflowHasWrite = true
@@ -3285,11 +3303,10 @@ func checkExternalTrigger(workflow parser.WorkflowFile) []Finding {
 				}
 			}
 			if !workflowHasWrite {
-				continue // suppressed — restricted permissions, no real risk
+				continue
 			}
 
 			severity := Medium
-			// Reduce severity for test/dev workflows
 			if strings.Contains(workflow.Path, "test") ||
 				strings.Contains(workflow.Path, "dev") ||
 				strings.Contains(workflow.Path, "debug") ||

--- a/pkg/rules/rules_test.go
+++ b/pkg/rules/rules_test.go
@@ -423,8 +423,8 @@ jobs:
 			hasIssueCommentFinding = true
 		}
 	}
-	if !hasIssueCommentFinding {
-		t.Error("EXTERNAL_TRIGGER_DEBUG should still fire on issue_comment regardless of permissions")
+	if hasIssueCommentFinding {
+		t.Error("EXTERNAL_TRIGGER_DEBUG should NOT fire on issue_comment with read-only permissions")
 	}
 
 	// Regression: flowlyt-scan.yml — has security-events: write but also contents: read.

--- a/pkg/rules/shell_injection.go
+++ b/pkg/rules/shell_injection.go
@@ -427,8 +427,9 @@ func isJobUsingSelfHostedRunner(job parser.Job) bool {
 	case []interface{}:
 		for _, runner := range runsOn {
 			if runnerStr, ok := runner.(string); ok {
+				// Skip dynamic expressions — can't determine at static analysis time
 				if strings.Contains(runnerStr, "${{") {
-					return false
+					continue
 				}
 				if !isManaged(runnerStr) {
 					return true

--- a/pkg/rules/shell_injection.go
+++ b/pkg/rules/shell_injection.go
@@ -392,6 +392,13 @@ func isJobUsingSelfHostedRunner(job parser.Job) bool {
 		"ubuntu-slim",
 	}
 
+	// GitHub variant runner patterns: ubuntu-latest-4-cores, macos-13-large, windows-2022-16core
+	githubVariantPatterns := []*regexp.Regexp{
+		regexp.MustCompile(`^ubuntu-(latest|[0-9]+\.[0-9]+)(-\d+-cores?|-xl)?$`),
+		regexp.MustCompile(`^macos-(latest|[0-9]+)(-large|-xlarge)?$`),
+		regexp.MustCompile(`^windows-(latest|[0-9]+)(-\d+core)?$`),
+	}
+
 	isManaged := func(label string) bool {
 		if githubHostedRunners[label] {
 			return true
@@ -402,9 +409,10 @@ func isJobUsingSelfHostedRunner(job parser.Job) bool {
 				return true
 			}
 		}
-		// GitHub variant suffixes: ubuntu-latest-xl, macos-13-large, etc.
-		if strings.HasPrefix(lower, "ubuntu-") || strings.HasPrefix(lower, "macos-") || strings.HasPrefix(lower, "windows-") {
-			return true
+		for _, pattern := range githubVariantPatterns {
+			if pattern.MatchString(lower) {
+				return true
+			}
 		}
 		return false
 	}

--- a/pkg/rules/shell_injection.go
+++ b/pkg/rules/shell_injection.go
@@ -420,7 +420,7 @@ func isJobUsingSelfHostedRunner(job parser.Job) bool {
 	switch runsOn := job.RunsOn.(type) {
 	case string:
 		// Matrix expansions can't be resolved statically — skip
-		if strings.Contains(runsOn, "${{ matrix.") {
+		if strings.Contains(runsOn, "${{ matrix.") || strings.Contains(runsOn, "${{matrix.") {
 			return false
 		}
 		// Other dynamic expressions (e.g. inputs.runner) may resolve to self-hosted
@@ -432,7 +432,7 @@ func isJobUsingSelfHostedRunner(job parser.Job) bool {
 		for _, runner := range runsOn {
 			if runnerStr, ok := runner.(string); ok {
 				// Matrix expansions can't be resolved statically — skip this label
-				if strings.Contains(runnerStr, "${{ matrix.") {
+				if strings.Contains(runnerStr, "${{ matrix.") || strings.Contains(runnerStr, "${{matrix.") {
 					continue
 				}
 				// Other dynamic expressions may resolve to self-hosted

--- a/pkg/rules/shell_injection.go
+++ b/pkg/rules/shell_injection.go
@@ -419,17 +419,25 @@ func isJobUsingSelfHostedRunner(job parser.Job) bool {
 
 	switch runsOn := job.RunsOn.(type) {
 	case string:
-		// Dynamic expressions — can't determine at static analysis time
-		if strings.Contains(runsOn, "${{") {
+		// Matrix expansions can't be resolved statically — skip
+		if strings.Contains(runsOn, "${{ matrix.") {
 			return false
+		}
+		// Other dynamic expressions (e.g. inputs.runner) may resolve to self-hosted
+		if strings.Contains(runsOn, "${{") {
+			return true
 		}
 		return !isManaged(runsOn)
 	case []interface{}:
 		for _, runner := range runsOn {
 			if runnerStr, ok := runner.(string); ok {
-				// Skip dynamic expressions — can't determine at static analysis time
-				if strings.Contains(runnerStr, "${{") {
+				// Matrix expansions can't be resolved statically — skip this label
+				if strings.Contains(runnerStr, "${{ matrix.") {
 					continue
+				}
+				// Other dynamic expressions may resolve to self-hosted
+				if strings.Contains(runnerStr, "${{") {
+					return true
 				}
 				if !isManaged(runnerStr) {
 					return true

--- a/pkg/rules/shell_injection.go
+++ b/pkg/rules/shell_injection.go
@@ -359,12 +359,13 @@ func hasUntrustedWorkflowTriggers(workflow parser.WorkflowFile) bool {
 
 // isJobUsingSelfHostedRunner checks if a job uses self-hosted runners
 func isJobUsingSelfHostedRunner(job parser.Job) bool {
-	// GitHub-hosted runner labels
+	// GitHub-hosted runner labels (exact matches)
 	githubHostedRunners := map[string]bool{
 		"ubuntu-latest":          true,
 		"ubuntu-20.04":           true,
 		"ubuntu-18.04":           true,
 		"ubuntu-22.04":           true,
+		"ubuntu-24.04":           true,
 		"windows-latest":         true,
 		"windows-2019":           true,
 		"windows-2022":           true,
@@ -372,28 +373,56 @@ func isJobUsingSelfHostedRunner(job parser.Job) bool {
 		"macos-11":               true,
 		"macos-12":               true,
 		"macos-13":               true,
+		"macos-14":               true,
+		"macos-15":               true,
 		"macos-latest-large":     true,
+		"macos-latest-xlarge":    true,
 		"ubuntu-latest-4-cores":  true,
 		"ubuntu-latest-8-cores":  true,
 		"ubuntu-latest-16-cores": true,
 	}
 
+	// Known managed runner prefixes from trusted CI-as-a-service providers
+	// (Namespace.so, Actuated, BuildJet, etc.)
+	managedRunnerPrefixes := []string{
+		"namespace-profile-",
+		"nscloud-",
+		"buildjet-",
+		"actuated-",
+		"ubuntu-slim",
+	}
+
+	isManaged := func(label string) bool {
+		if githubHostedRunners[label] {
+			return true
+		}
+		lower := strings.ToLower(label)
+		for _, prefix := range managedRunnerPrefixes {
+			if strings.HasPrefix(lower, prefix) {
+				return true
+			}
+		}
+		// GitHub variant suffixes: ubuntu-latest-xl, macos-13-large, etc.
+		if strings.HasPrefix(lower, "ubuntu-") || strings.HasPrefix(lower, "macos-") || strings.HasPrefix(lower, "windows-") {
+			return true
+		}
+		return false
+	}
+
 	switch runsOn := job.RunsOn.(type) {
 	case string:
-		// Handle matrix expressions like ${{ matrix.os }}
-		if strings.Contains(runsOn, "${{") && strings.Contains(runsOn, "matrix") {
-			// For matrix expressions, be conservative and don't flag as self-hosted
-			// unless we can definitively determine otherwise
+		// Dynamic expressions — can't determine at static analysis time
+		if strings.Contains(runsOn, "${{") {
 			return false
 		}
-		return !githubHostedRunners[runsOn]
+		return !isManaged(runsOn)
 	case []interface{}:
 		for _, runner := range runsOn {
 			if runnerStr, ok := runner.(string); ok {
-				if strings.Contains(runnerStr, "${{") && strings.Contains(runnerStr, "matrix") {
-					return false // Conservative approach for matrix runners
+				if strings.Contains(runnerStr, "${{") {
+					return false
 				}
-				if !githubHostedRunners[runnerStr] {
+				if !isManaged(runnerStr) {
 					return true
 				}
 			}

--- a/pkg/rules/supply_chain.go
+++ b/pkg/rules/supply_chain.go
@@ -17,6 +17,7 @@ limitations under the License.
 package rules
 
 import (
+	"regexp"
 	"strings"
 
 	"github.com/harekrishnarai/flowlyt/pkg/linenum"
@@ -63,7 +64,7 @@ func checkKnownVulnerableActions(workflow parser.WorkflowFile) []Finding {
 			}
 
 			// Skip local actions — these are in the same repo and already covered by LOCAL_ACTION_USAGE
-			if strings.HasPrefix(step.Uses, "./") {
+			if strings.HasPrefix(step.Uses, "./") || strings.HasPrefix(step.Uses, "../") {
 				continue
 			}
 
@@ -270,7 +271,7 @@ func checkUntrustedActionSources(workflow parser.WorkflowFile) []Finding {
 					version := actionParts[1]
 					if len(version) == 40 && isHexString(version) {
 						isPinnedToSHA = true
-					} else if !strings.HasPrefix(version, "v") {
+					} else if !strings.HasPrefix(version, "v") && !isSemverLike(version) {
 						isBranchRef = true
 					}
 				}
@@ -417,4 +418,12 @@ func checkDeprecatedActions(workflow parser.WorkflowFile) []Finding {
 	}
 
 	return findings
+}
+
+// isSemverLike returns true if the string looks like a semantic version
+// without a v prefix (e.g., "1.2.3", "2.0", "1.0.0-beta").
+var semverLikePattern = regexp.MustCompile(`^\d+\.\d+(\.\d+)?`)
+
+func isSemverLike(s string) bool {
+	return semverLikePattern.MatchString(s)
 }

--- a/pkg/rules/supply_chain.go
+++ b/pkg/rules/supply_chain.go
@@ -62,7 +62,12 @@ func checkKnownVulnerableActions(workflow parser.WorkflowFile) []Finding {
 				stepName = "Step " + string(rune('1'+stepIdx))
 			}
 
-			// Parse action name and version
+			// Skip local actions — these are in the same repo and already covered by LOCAL_ACTION_USAGE
+			if strings.HasPrefix(step.Uses, "./") {
+				continue
+			}
+
+			// Parse action name
 			actionParts := strings.Split(step.Uses, "@")
 			actionName := actionParts[0]
 			version := ""
@@ -258,31 +263,36 @@ func checkUntrustedActionSources(workflow parser.WorkflowFile) []Finding {
 
 			// Check if action is from an untrusted source
 			if !vdb.IsTrustedPublisher(actionName) {
-				// Additional checks for suspicious patterns
-				isSuspicious := false
-				suspiciousReason := ""
-
-				// Check for actions using tags instead of SHA
+				// Determine version pinning status
+				isPinnedToSHA := false
+				isBranchRef := false
 				if len(actionParts) > 1 {
 					version := actionParts[1]
-					if !strings.HasPrefix(version, "v") && len(version) != 40 {
-						// Not a semantic version or SHA - might be a branch name
-						isSuspicious = true
-						suspiciousReason = "uses branch name instead of pinned version"
+					if len(version) == 40 {
+						isPinnedToSHA = true
+					} else if !strings.HasPrefix(version, "v") {
+						isBranchRef = true
 					}
+				}
+
+				// SHA-pinned third-party actions are low risk — supply chain attack
+				// requires compromising the exact commit, not just a tag/branch
+				if isPinnedToSHA {
+					continue
+				}
+
+				// Determine severity based on version pinning
+				severity := Medium
+				description := "Action is from an untrusted or unknown publisher"
+				if isBranchRef {
+					severity = High
+					description = "Action is from an untrusted publisher and uses branch name instead of pinned version"
 				}
 
 				// Check for actions with unusual naming patterns
 				if strings.Contains(actionName, "..") || strings.Contains(actionName, "--") {
-					isSuspicious = true
-					suspiciousReason = "unusual naming pattern"
-				}
-
-				severity := Medium
-				description := "Action is from an untrusted or unknown publisher"
-				if isSuspicious {
 					severity = High
-					description = "Action is from an untrusted publisher and " + suspiciousReason
+					description = "Action is from an untrusted publisher with unusual naming pattern"
 				}
 
 				pattern := linenum.FindPattern{

--- a/pkg/rules/supply_chain.go
+++ b/pkg/rules/supply_chain.go
@@ -129,6 +129,11 @@ func checkUnpinnableActions(workflow parser.WorkflowFile) []Finding {
 				continue
 			}
 
+			// Skip local actions — already covered by LOCAL_ACTION_USAGE
+			if strings.HasPrefix(step.Uses, "./") || strings.HasPrefix(step.Uses, "../") {
+				continue
+			}
+
 			stepName := step.Name
 			if stepName == "" {
 				stepName = "Step " + string(rune('1'+stepIdx))
@@ -183,6 +188,11 @@ func checkTyposquattingActions(workflow parser.WorkflowFile) []Finding {
 				continue
 			}
 
+			// Skip local actions — already covered by LOCAL_ACTION_USAGE
+			if strings.HasPrefix(step.Uses, "./") || strings.HasPrefix(step.Uses, "../") {
+				continue
+			}
+
 			stepName := step.Name
 			if stepName == "" {
 				stepName = "Step " + string(rune('1'+stepIdx))
@@ -234,6 +244,11 @@ func checkUntrustedActionSources(workflow parser.WorkflowFile) []Finding {
 	for jobName, job := range workflow.Workflow.Jobs {
 		for stepIdx, step := range job.Steps {
 			if step.Uses == "" {
+				continue
+			}
+
+			// Skip local actions — already covered by LOCAL_ACTION_USAGE
+			if strings.HasPrefix(step.Uses, "./") || strings.HasPrefix(step.Uses, "../") {
 				continue
 			}
 

--- a/pkg/rules/supply_chain.go
+++ b/pkg/rules/supply_chain.go
@@ -268,7 +268,7 @@ func checkUntrustedActionSources(workflow parser.WorkflowFile) []Finding {
 				isBranchRef := false
 				if len(actionParts) > 1 {
 					version := actionParts[1]
-					if len(version) == 40 {
+					if len(version) == 40 && isHexString(version) {
 						isPinnedToSHA = true
 					} else if !strings.HasPrefix(version, "v") {
 						isBranchRef = true


### PR DESCRIPTION
## Summary

- Add three new security rules for detecting vulnerable CI/CD patterns involving containers and AI agents
- Significantly reduce false positives across multiple existing rules
- Enable context-aware suppression and cancellation in concurrent scan paths

## New Rules

### `DOCKER_EXEC_WITH_SECRETS_ON_FORK_CODE`
Detects `pull_request_target` workflows that run Docker containers with secrets forwarded via `-e`/`--env` while operating on fork code (verified via untrusted checkout evidence). Only flags when:
- Workflow has `pull_request_target` trigger
- Job checks out PR head ref (untrusted code)
- Docker run forwards secrets without `--network=none`

### `AI_AGENT_ON_UNTRUSTED_CODE`
Detects AI agent invocations (Claude, Copilot, GPT, Aider, etc.) processing fork-controlled code with secrets available in `pull_request_target` workflows. Now checks for `--network=none` mitigation and resolves line numbers for `uses:`-based detections.

### `AI_AGENT_COMMENT_TRIGGERED` (NEW)
Detects AI agents triggered by `issue_comment` or `pull_request_review_comment` without `author_association` gating. Two attack tiers:
- **Critical/High** — Secrets passed to agent → prompt injection enables secret exfiltration
- **Medium** — No secrets but agent still runs → denial-of-wallet (any external user can spam @mentions to burn API credits)

Covers: Claude Code Action, Gemini, Copilot, CodeRabbit, Sourcery, Sweep, Aider, Devin, Qodo, Cursor + CLI variants.

Suppressed when workflow already gates on `author_association == 'MEMBER'/'OWNER'/'COLLABORATOR'`.

## False Positive Reductions

- **Supply chain**: Skip SHA-pinned actions (with proper hex validation), skip local actions
- **Runner detection**: Narrow `isManaged` to exact GitHub-hosted patterns (no longer matches `ubuntu-self-hosted`)
- **External triggers**: `issue_comment` now gated on write permissions (read-only is benign)
- **Docker/agent rules**: Require untrusted checkout evidence before flagging `pull_request_target` workflows
- **Reusable workflow detection**: Fixed to job-level only (step-level `.github/workflows/` is invalid syntax)
- **Secrets scope**: Use parsed `job.Secrets` field instead of file-global `strings.Contains("secrets:")`

## Infrastructure Fixes

- Restore `ctx.Done()` cancellation check in concurrent scan goroutine
- `detectRepositoryOwner`: falls back to directory name, handles `ssh://` URL format
- AI agent rule resolves line numbers for both `run:` and `uses:` steps

## Test Coverage

- 8 test cases for docker/agent exposure rules
- Author association gate suppression test
- Denial-of-wallet detection test
- Updated `TestExternalTriggerPermissions` for new `issue_comment` behavior